### PR TITLE
feat(volume): suppression du volume docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV TOMCAT_VERSION_FULL  7.0.69
 # Download and install
 RUN set -x \
   && apk add --no-cache su-exec \
-  && apk add --update curl \
+  && apk add --update curl unzip \
   && addgroup tomcat && adduser -s /bin/bash -D -G tomcat tomcat \
   && mkdir /opt \
   && curl -LO https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION_MAJOR}/v${TOMCAT_VERSION_FULL}/bin/apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz \
@@ -56,8 +56,6 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 
 RUN chmod 755 /docker-entrypoint.sh
-
-VOLUME /data
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
Le volume Docker étant défini dans le Dockerfile, lorsque celui-ci est surchargé par docker-compose, le démon docker va créer un volume anonyme polluant pour rien le répertoire /var/lib/docker/volumes.

En le supprimant dans le Dockerfile, il est toujours possible de l'utiliser via docker-compose et le volume anonyme n'est plus créé.

Plus d'information ici: https://devops.stackexchange.com/questions/2967/why-are-unnamed-volumes-created-when-docker-compose-up-is-run-and-do-these-dou