### PR TITLE
Remove VOLUME "/data" definition to avoid anonymous volume while using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ COPY docker-entrypoint.sh /
 
 RUN chmod 755 /docker-entrypoint.sh
 
-VOLUME /data
-
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["catalina","run"]

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<junit.version>4.11</junit.version>
 		<slf4j.version>1.7.5</slf4j.version>
 	</properties>
-	<version>0.12.14</version>
+	<version>0.12.15</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 		<build-version>1.0.0-SNAPSHOT</build-version>
 		<junit.version>4.11</junit.version>
 		<slf4j.version>1.7.5</slf4j.version>
+  		<maven.compiler.source>1.8</maven.compiler.source>
+  		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 	<version>0.12.15</version>
 	<build>


### PR DESCRIPTION
Remove VOLUME "/data" definition to avoid anonymous volume while using docker-compose