### PR TITLE
fix: return null if parsing the json failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .settings
 .project
+.idea
+*.iml

--- a/src/main/java/org/apache/chemistry/opencmis/utils/FilePersistenceLoader.java
+++ b/src/main/java/org/apache/chemistry/opencmis/utils/FilePersistenceLoader.java
@@ -83,7 +83,7 @@ public class FilePersistenceLoader {
                     // if metadata file exists then meta is the CMIS Object
                     so = meta;
                 } else {
-                    LOG.warn("Missing metadata file for " + child.getAbsolutePath());
+                    LOG.warn("Missing metadata or malformed file for " + child.getAbsolutePath());
                     so.setProperties(new LinkedHashMap<String, PropertyData<?>>());
                     so.setTypeId(BaseTypeId.CMIS_FOLDER.value());
                     so.setName(child.getName());
@@ -117,7 +117,7 @@ public class FilePersistenceLoader {
                     // if metadata file exists then meta is the CMIS Object
                     so = meta;
                 } else {
-                    LOG.warn("Missing metadata file for " + child.getAbsolutePath());
+                    LOG.warn("Missing metadata or malformed file for " + child.getAbsolutePath());
                     so.setProperties(new LinkedHashMap<String, PropertyData<?>>());
                     so.setName(child.getName());
                     so.setTypeId(BaseTypeId.CMIS_DOCUMENT.value());

--- a/src/main/java/org/apache/chemistry/opencmis/utils/StoredObjectJsonSerializer.java
+++ b/src/main/java/org/apache/chemistry/opencmis/utils/StoredObjectJsonSerializer.java
@@ -195,8 +195,8 @@ public class StoredObjectJsonSerializer {
         try {
             result = (JSONObject) new JSONParser().parse(jsonString);
         } catch (JSONParseException e) {
-        	result = new JSONObject();
             e.printStackTrace();
+            return null;
         }
         StoredObject so = null;
         if ("cmis:folder".equals(result.get(PropertyIds.OBJECT_TYPE_ID))) {


### PR DESCRIPTION
Using a newly constructed JSONObject when parsing the JSON fails, results in a NullPointerException because we try to get a property "properties" from a Map which yields "null" and throw the exception when we try to iterate over it.

![npe](https://user-images.githubusercontent.com/4912348/86606193-035c1a00-bfa8-11ea-8125-d009487ad7bc.png)
