### PR TITLE
chore(ci): add github action jobs

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: 3Jmf3Ynz8xZavoB3t35pKPCGsHdzEsFQP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build job
+
+on: push
+
+jobs:
+  test:
+    name: Test - Units & Integrations
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Maven test
+        run: mvn test -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release job
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    name: Package WAR and create docker image
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ secrets.DOCKER_REPO }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+      - name: Prepare
+        run: mvn clean install -DskipTests -B
+      - name: Login to Docker Hub
+        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
+      - name: Build Docker image
+        run: docker build -t $REPO:latest -t $REPO:${{steps.tag.outputs.tag}} .
+      - name: Publish Docker image
+        run: docker push $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: java


### PR DESCRIPTION
This PR add Github Actions CI management. 

I added two kind of jobs :
- build job 
- release job

The build job run project units tests on all branches and the release job create docker images and push them to docker hub.

<img width="917" alt="capture" src="https://user-images.githubusercontent.com/1223419/116623892-3ca2b380-a947-11eb-9f48-17fa1ba4b276.png">

Configuration : 

This secrets must be added to the project configuration : 
- DOCKER_REPO : Docker Hub repo ex: mgdis/lightweightcmisserver
- DOCKER_USER
- DOCKER_PASS 

Reviewers : @johanlelan @SamyLegal @sebaplaza 