### PR TITLE
chore(ci): update release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Login to Docker Hub
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
       - name: Build Docker image
-        run: docker build -t $REPO:latest -t $REPO:${{steps.tag.outputs.tag}} .
+        run: docker build -t $REPO:${{steps.tag.outputs.tag}} .
       - name: Publish Docker image
-        run: docker push $REPO
+        run: docker push $REPO:${{steps.tag.outputs.tag}}


### PR DESCRIPTION
A new PR to fix a small issue of the previous one.

Docker image tag and push is now correct.

Test example : 
![docker](https://user-images.githubusercontent.com/1223419/116659608-24a45180-a992-11eb-806d-05f4e6688319.png)

I'll add those changes on the v0.12 branch with the next PR 🙂