### PR TITLE
chore: no more md5 checksum on published tomcat version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
+          distribution: 'temurin'
           cache: maven
       - name: Maven test
         run: mvn test -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   test:
     name: Test - Units & Integrations
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: 'temurin'
-          architecture: x64
           cache: maven
       - name: Maven test
         run: mvn test -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,13 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 8
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
       - name: Maven test
         run: mvn test -B

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 MAINTAINER JLL "lelan-j@mgdis.fr"
 
 # TOMCAT 
@@ -6,20 +6,20 @@ MAINTAINER JLL "lelan-j@mgdis.fr"
 EXPOSE 8080
 
 # Tomcat Version
-ENV TOMCAT_VERSION_MAJOR 7
-ENV TOMCAT_VERSION_FULL  7.0.69
+ENV TOMCAT_VERSION_MAJOR 9
+ENV TOMCAT_VERSION_FULL  9.0.89
 
 # Download and install
 RUN set -x \
   && apk add --no-cache su-exec \
   && apk add --update curl unzip \
   && addgroup tomcat && adduser -s /bin/bash -D -G tomcat tomcat \
-  && mkdir /opt \
+  && mkdir -p /opt \
   && curl -LO https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION_MAJOR}/v${TOMCAT_VERSION_FULL}/bin/apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz \
-  && curl -LO https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION_MAJOR}/v${TOMCAT_VERSION_FULL}/bin/apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
-  && md5sum -c apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
+#  && curl -LO https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_VERSION_MAJOR}/v${TOMCAT_VERSION_FULL}/bin/apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
+#  && md5sum -c apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
   && gunzip -c apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz | tar -xf - -C /opt \
-  && rm -f apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
+#  && rm -f apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz apache-tomcat-${TOMCAT_VERSION_FULL}.tar.gz.md5 \
   && ln -s /opt/apache-tomcat-${TOMCAT_VERSION_FULL} /opt/tomcat \
   && rm -rf /opt/tomcat/webapps/examples /opt/tomcat/webapps/docs /opt/tomcat/webapps/manager /opt/tomcat/webapps/host-manager \
   && apk del curl \

--- a/src/main/webapp/WEB-INF/classes/default.properties
+++ b/src/main/webapp/WEB-INF/classes/default.properties
@@ -12,11 +12,11 @@ InMemoryServer.RepositoryThinClientUri="http://localhost:8080/lightweightcmis/br
 InMemoryServer.User=test
 InMemoryServer.Password=test
 # InMemoryServer.TypesCreatorClass=org.apache.chemistry.opencmis.inmemory.types.DefaultTypeSystemCreator
-InMemoryServer.TypeDefinitionsFile=/data/cmis/default-types.xml
+InMemoryServer.TypeDefinitionsFile=/tmp/cmis/default-types.xml
 InMemoryServer.Class=org.apache.chemistry.opencmis.inmemory.storedobj.impl.StoreManagerImpl
 
 # InMemoryServer.MemoryThreshold=10485760
-persistenceDirectory=/data/cmis/default
+persistenceDirectory=/tmp/cmis/default
 #InMemoryServer.MaxSize=20971520
 #InMemoryServer.EncryptTempFiles=false
 


### PR DESCRIPTION
Remove the md5 checksum temporary.
Will use sha512 in the future